### PR TITLE
Adding ability to 'Use' items without them being removed from your inventory

### DIFF
--- a/scripts/events.js
+++ b/scripts/events.js
@@ -64,6 +64,9 @@
                         if (payload[i].args.includes(e.which)) {
                             code = code + payload[i].contents;
                         }
+                        if ('used' == e.context && payload[i].args.includes(e.moved[0])) {
+                            code = code + payload[i].contents;
+                        }
                     }
                 }
                 new Wikifier(null, code);

--- a/scripts/simple-inventory.js
+++ b/scripts/simple-inventory.js
@@ -179,6 +179,21 @@
             return this; // for chaining
         },
         
+        use : function () { // attempt to use this item
+            var items = [].slice.call(arguments).flatten(),
+                inventory = this; // we need to access this in the <array>.forEach()
+            if (items && items.length) {
+                var moved = [];
+                items.forEach(function (item) {
+                    if (inventory.has(item)) {
+                        moved.push(item); // for the event below
+                    }
+                });
+                _attachEvent(this, null, moved, 'used');
+            }
+            return this; // for chaining
+        },
+
         sort : function () { // sorts this inventory
             this.inv = this.inv.sort();
             _attachEvent(this, null, null, 'sort');
@@ -255,6 +270,12 @@
                 
                 // add click event handler
                 $link.ariaClick(function () {
+                    if ('Use' == drop)
+                    {
+                        inv.use(item);
+                        return;
+                    }
+
                     if (loc) {
                         inv.transfer(loc, item);
                     } else {


### PR DESCRIPTION
This way users can 'try' solutions to puzzles without their inventory items leaving their inventory.  It feels a little hack-y to watch for the string 'Use' so I'm open to alternatives.

[simple-inventory-example.txt](https://github.com/ChapelR/custom-macros-for-sugarcube-2/files/6190178/simple-inventory-example.txt)
