### PR TITLE
Update link to dialog-api-macro-set documentation

### DIFF
--- a/scripts/dialog-api-macro-set.js
+++ b/scripts/dialog-api-macro-set.js
@@ -1,6 +1,6 @@
 // dialog API macro set, by chapel; for sugarcube 2
 // version 1.3.0
-// see the documentation: https://github.com/ChapelR/custom-macros-for-sugarcube-2#dialog-api-macros
+// see the documentation: https://github.com/ChapelR/custom-macros-for-sugarcube-2/blob/master/docs/dialog-api-macro-set.md
 
 // <<dialog>> macro
 Macro.add('dialog', {


### PR DESCRIPTION
Based on the comment I modified, it seems the intention is to link to the dialog macro's documentation, but the link was taking you to the top of the root README. 

